### PR TITLE
Issue 46 - Added a field for users which indicates if they compete in contests

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -29,6 +29,7 @@ class Admin::UsersController < Admin::BaseController
     @user.attributes = params[:user].except(:unencrypted_password, :unencrypted_password_confirmation)
     
     @user.admin = params[:user][:admin]
+    @user.contester = params[:user][:contester]
     unless params[:user][:unencrypted_password].blank?
       @user.unencrypted_password = params[:user][:unencrypted_password]
       @user.unencrypted_password_confirmation = params[:user][:unencrypted_password_confirmation]

--- a/app/models/contest.rb
+++ b/app/models/contest.rb
@@ -52,7 +52,7 @@ class Contest < ActiveRecord::Base
     results = []
     self.contest_start_events.find_each(:include => :user) do |event|
       runs = self.runs.during_contest.find(:first, :conditions => { :user_id => event.user_id })
-      next if event.user.admin? or runs.nil?
+      next if (not event.user.participates_in_contests?) or runs.nil?
       
       total = 0
       

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -19,7 +19,7 @@ class User < ActiveRecord::Base
   validates_presence_of :city
   
   attr_accessor :unencrypted_password
-  attr_protected :unencrypted_password, :unencrypted_password_confirmation, :admin
+  attr_protected :unencrypted_password, :unencrypted_password_confirmation, :admin, :contester
 
   has_many :contest_start_events, :dependent => :destroy
   has_many :runs, :dependent => :destroy, :select => (Run.column_names - ["log", "source_code"]).join(",")
@@ -184,6 +184,10 @@ class User < ActiveRecord::Base
   
   def times_rated
     rating_changes.count
+  end
+  
+  def participates_in_contests?
+    (not admin) && contester
   end
   
   private

--- a/app/views/admin/users/_user_fields.html.erb
+++ b/app/views/admin/users/_user_fields.html.erb
@@ -27,3 +27,7 @@
   <%= f.label :admin, "Администратор?" %>
   <%= f.check_box :admin %>
 </p>
+<p>
+  <%= f.label :contester, "Състезател?" %>
+  <%= f.check_box :contester %>
+</p>

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -8,6 +8,7 @@
       <th>Име</th>
       <th>Email</th>
       <th>Админ?</th>
+	  <th>Състезател?</th>
       <th>Действия</th>
     </tr>
   <% for user in @users %>
@@ -16,6 +17,7 @@
       <td><%= user.name %></td>
       <td><%= user.email %></td>
       <td><%= check_box_tag "is_admin_#{user.login}", "1", user.admin?, :disabled => true %></td>
+	  <td><%= check_box_tag "is_contester_#{user.login}", "1", user.contester?, :disabled => true %></td>
       <td>
         <%= link_to "Админ преглед", admin_user_path(user) %> |
         <%= link_to "Преглед", user_path(user) %> |

--- a/db/migrate/20101016192458_add_contester_to_user.rb
+++ b/db/migrate/20101016192458_add_contester_to_user.rb
@@ -1,0 +1,11 @@
+class AddContesterToUser < ActiveRecord::Migration
+  def self.up
+    add_column :users, :contester, :boolean, :default => 1
+
+  end
+
+  def self.down
+    remove_column :users, :contester
+
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -9,11 +9,11 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20100608062740) do
+ActiveRecord::Schema.define(:version => 20101016192458) do
 
   create_table "categories", :force => true do |t|
     t.string   "name"
-    t.text     "description", :limit => 16777215
+    t.text     "description"
     t.datetime "created_at"
     t.datetime "updated_at"
   end
@@ -24,7 +24,7 @@ ActiveRecord::Schema.define(:version => 20100608062740) do
   end
 
   create_table "configurations", :force => true do |t|
-    t.string   "key",                              :null => false
+    t.string   "key",        :default => "",       :null => false
     t.string   "value"
     t.string   "value_type", :default => "string", :null => false
     t.datetime "created_at"
@@ -49,8 +49,8 @@ ActiveRecord::Schema.define(:version => 20100608062740) do
   add_index "contest_start_events", ["user_id", "contest_id"], :name => "index_contest_start_events_on_user_id_and_contest_id", :unique => true
 
   create_table "contests", :force => true do |t|
-    t.string   "set_code",                           :null => false
-    t.string   "name",                               :null => false
+    t.string   "set_code",        :default => "",    :null => false
+    t.string   "name",            :default => "",    :null => false
     t.datetime "start_time",                         :null => false
     t.datetime "end_time",                           :null => false
     t.integer  "duration",                           :null => false
@@ -81,18 +81,18 @@ ActiveRecord::Schema.define(:version => 20100608062740) do
   end
 
   create_table "messages", :force => true do |t|
-    t.string   "subject",     :null => false
-    t.text     "body",        :null => false
+    t.string   "subject",     :default => "", :null => false
+    t.text     "body",                        :null => false
     t.text     "emails_sent"
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
   create_table "news", :force => true do |t|
-    t.datetime "new_time",                  :null => false
-    t.string   "file",       :limit => 64,  :null => false
-    t.string   "topic",      :limit => 128, :null => false
-    t.text     "content",                   :null => false
+    t.datetime "new_time",                                  :null => false
+    t.string   "file",       :limit => 64,  :default => "", :null => false
+    t.string   "topic",      :limit => 128, :default => "", :null => false
+    t.text     "content",                                   :null => false
     t.datetime "created_at"
     t.datetime "updated_at"
   end
@@ -100,7 +100,7 @@ ActiveRecord::Schema.define(:version => 20100608062740) do
   create_table "problems", :force => true do |t|
     t.integer  "contest_id",                                                                     :null => false
     t.string   "letter",       :limit => 16
-    t.string   "name",         :limit => 64,                                                     :null => false
+    t.string   "name",         :limit => 64,                               :default => "",       :null => false
     t.decimal  "time_limit",                 :precision => 5, :scale => 2,                       :null => false
     t.datetime "created_at"
     t.datetime "updated_at"
@@ -121,7 +121,7 @@ ActiveRecord::Schema.define(:version => 20100608062740) do
   create_table "runs", :force => true do |t|
     t.integer  "problem_id",                                                         :null => false
     t.integer  "user_id",                                                            :null => false
-    t.string   "language",                                                           :null => false
+    t.string   "language",                                    :default => "",        :null => false
     t.binary   "source_code",                                                        :null => false
     t.string   "status",                                      :default => "pending", :null => false
     t.text     "log"
@@ -132,11 +132,10 @@ ActiveRecord::Schema.define(:version => 20100608062740) do
     t.integer  "max_memory"
   end
 
-  add_index "runs", ["status", "created_at"], :name => "status_created_at"
   add_index "runs", ["user_id", "problem_id"], :name => "index_runs_on_user_id_and_problem_id"
 
   create_table "sessions", :force => true do |t|
-    t.string   "session_id", :null => false
+    t.string   "session_id", :default => "", :null => false
     t.text     "data"
     t.datetime "created_at"
     t.datetime "updated_at"
@@ -149,12 +148,13 @@ ActiveRecord::Schema.define(:version => 20100608062740) do
     t.string   "login",      :limit => 40
     t.string   "name",       :limit => 100, :default => ""
     t.string   "email",      :limit => 100
+    t.string   "city",       :limit => 100, :default => "",    :null => false
     t.datetime "created_at"
     t.datetime "updated_at"
     t.boolean  "admin",                     :default => false
-    t.string   "password",   :limit => 40,                     :null => false
-    t.string   "city"
+    t.string   "password",   :limit => 40
     t.string   "token",      :limit => 16
+    t.boolean  "contester",                 :default => true
   end
 
   add_index "users", ["login"], :name => "index_users_on_login", :unique => true

--- a/test/factories.rb
+++ b/test/factories.rb
@@ -32,3 +32,8 @@ Factory.define :contest_result do |c|
   c.contest { |contest| contest.association(:contest) }
   c.user { |user| user.association(:user) }
 end
+
+Factory.define :contest_start_event do |c|
+  c.contest { |contest| contest.association(:contest) }
+  c.user { |user| user.association(:user) }
+end

--- a/test/unit/contest_result_test.rb
+++ b/test/unit/contest_result_test.rb
@@ -1,8 +1,33 @@
 require 'test_helper'
 
 class ContestResultTest < ActiveSupport::TestCase
-  # Replace this with your real tests.
-  test "the truth" do
-    assert true
+  def setup
+    [User, Contest].each(&:destroy_all)
+  end
+  
+  test "results contain only contesters" do
+    user_admin = Factory(:user, :admin => true)
+    assert (not user_admin.participates_in_contests?)
+    user_contester = Factory(:user, :contester => true, :admin => false)
+    assert user_contester.participates_in_contests?
+    
+    contest = Factory(:contest)
+    contest.problems << Factory(:problem, :name => "Problem", :contest => contest) while contest.problems.length < 3
+    assert contest.problems.length > 0
+    
+    # Add first contester's runs
+    contest_start_event1 = Factory(:contest_start_event, :contest => contest, :user => user_admin)    
+    run1 = Factory(:run, :user => user_admin, :problem => contest.problems[0])
+    assert user_admin.runs.length == 1
+    assert contest.problems[0].runs.length == 1
+
+    # Add second contester's runs
+    contest_start_event2 = Factory(:contest_start_event, :contest => contest, :user => user_contester)
+    run2 = Factory(:run, :user => user_contester, :problem => contest.problems[0])
+    assert user_contester.runs.length == 1    
+    assert contest.problems[0].runs.length == 1
+    
+    contest_results = contest.generate_contest_results
+    assert contest_results.length == 1
   end
 end

--- a/test/unit/user_test.rb
+++ b/test/unit/user_test.rb
@@ -1,0 +1,23 @@
+require 'test_helper'
+class UserTest < ActiveSupport::TestCase
+  
+  test "the truth" do
+    assert true
+  end
+  
+  test "user is contester by default" do
+    user = User.new
+    assert user.contester?
+  end
+    
+  test "only non admin contester can compete" do
+    user = User.new
+    assert user.participates_in_contests?
+    user.admin = 1
+    assert (not user.participates_in_contests?)
+    user.contester = 0
+    assert (not user.participates_in_contests?)
+    user.admin = 0
+    assert (not user.participates_in_contests?)
+  end
+end


### PR DESCRIPTION
Each user is created by default as a contester but its status can be changed by an admin. Haven't implemented logic for allowing the clients to choose for themselves yet, not sure if we want this behaviour.

Contest results are generated only for non-admins users who are contesters.

Created several unit tests to check the new functionality.
