### PR TITLE
Fix directory creation

### DIFF
--- a/app/controllers/admin/problems_controller.rb
+++ b/app/controllers/admin/problems_controller.rb
@@ -162,7 +162,7 @@ class Admin::ProblemsController < Admin::BaseController
         # Extract the bundle
         Zip::ZipFile.foreach(@upload.tempfile.path) do |filename|
           if filename.file? and !filename.name.include?('/')
-            dest = File.join(@problem.tests_dir, filename.name).downcase
+            dest = File.join(@problem.tests_dir, filename.name)
             FileUtils.rm(dest) if File.exists?(dest)
             filename.extract dest
           end

--- a/app/controllers/admin/problems_controller.rb
+++ b/app/controllers/admin/problems_controller.rb
@@ -169,7 +169,7 @@ class Admin::ProblemsController < Admin::BaseController
         end
       else
         dest = File.join(@problem.tests_dir, @upload.original_filename)
-        FileUtils.cp @upload.local_path, dest
+        FileUtils.cp @upload.path, dest
         # Set the permissions of the copied file to the right ones. This is
         # because the uploads are created with 0600 permissions in the /tmp
         # folder. The 0666 & ~File.umask will set the permissions to the default


### PR DESCRIPTION
### Problems with the directory creation of newly uploaded files
There are two problems and both of them are regarding the [problems_controller.rb](https://github.com/valo/maycamp_arena/blob/master/app/controllers/admin/problems_controller.rb)
#### Uploading a .zip archive
There is a problem when uploading a .zip archive in a case sensitive file system. The string, containing the name of the directory path, in which the archive is going to be extracted, is being changed to .downcase and this conflicts with case sensitive files systems (Tested on Ubuntu 14.04 LTS, 64bit). In this case the cucumber
```bash
$ bundle exec cucumber
```
tests fail. Therefore the name of the directory path should not be changed and left in its original version.

#### Uploading a single unarchived file
After the upload the file is being moved from its current ("temporary") directory to the one, which has been made for the task (in the case this is the directory "dest"). However the current directory of the path is not .local_path but only .path