### PR TITLE
Synchronize on the DB level when fetching runs for grading

### DIFF
--- a/app/services/grade_run.rb
+++ b/app/services/grade_run.rb
@@ -9,7 +9,7 @@ class GradeRun
     run.update_attributes(:status => Run::JUDGING) unless dry_run
 
     puts "Judging run with id #{run.id} with #{tests} tests"
-    
+
     Dir.chdir(File.join(Rails.root, "sandbox")) do
       File.open("grader.log", "w") do |f|
         f.sync = true
@@ -25,7 +25,7 @@ class GradeRun
 
           status = run_tests(run, tests)
           puts "final result: #{status.inspect}"
-          
+
           run.update_attributes(:status => status, :log => File.read("grader.log")) unless dry_run
         end
 
@@ -111,7 +111,7 @@ class GradeRun
         checker = File.join(Rails.root, "ext/diff.rb")
         verbose_system "#{checker} #{run.problem.diff_parameters} #{answer_file} output"
       end
-      
+
       if $?.exitstatus != 0
         "wa"
       else
@@ -149,7 +149,7 @@ class GradeRun
       old_stdout, old_stderr = $stdout.dup, $stderr.dup
       STDOUT.reopen(new_stdout)
       STDERR.reopen(new_stderr)
-      
+
       yield
     ensure
       STDOUT.reopen(old_stdout)

--- a/lib/grader.rb
+++ b/lib/grader.rb
@@ -2,11 +2,11 @@ class Grader
   def initialize
     @tests_updated_at = SyncTests.new(Time.at(0)).call
   end
-  
+
   def run
     running = true
     puts "Ready to grade"
-    
+
     while running do
       ["INT", "TERM"].each do |signal|
         Signal.trap(signal) do
@@ -14,25 +14,29 @@ class Grader
           running = false
         end
       end
-      
+
       @tests_updated_at = SyncTests.new(@tests_updated_at).call
-      
-      if run = Run.where(:status => Run::WAITING).order("runs.created_at ASC").first
-        GradeRun.new(run).call
-      elsif run = Run.where(:status => Run::CHECKING).order("runs.created_at ASC").first
-        GradeRun.new(run, 1)
-      else
-        sleep 1
-      end
+
+      sleep 1 unless find_and_grade_run
+    end
+  end
+
+  def find_and_grade_run
+    if run = acquire_run(Run::WAITING)
+      GradeRun.new(run).call
+    elsif run = acquire_run(Run::CHECKING)
+      GradeRun.new(run, 1).call
+    else
+      false
     end
   end
 
   def benchmark(samples = 100)
     @tests_updated_at = SyncTests.new(@tests_updated_at).call
-    
+
     total_runs = 0
     total_factors = 0
-    
+
     total_factor = Run.where(:total_points => 100).where("max_time > 0").order("RAND()").limit(samples).each do |run|
       original_time = run.max_time
       original_points = run.total_points
@@ -41,16 +45,32 @@ class Grader
 
       run.update_time_and_mem
       run.update_total_points
-      
+
       next if original_points != run.total_points
-      
+
       total_factors += original_time / run.max_time
       total_runs += 1
     end
-    
+
     puts "The bech factor of the machine is #{total_factors / total_runs}"
   end
 
   private
-    attr_reader :tests_updated_at
+
+  attr_reader :tests_updated_at
+
+  def acquire_run(status)
+    run = Run.where(status: status).order(created_at: :asc).first
+
+    return unless run
+
+    Run.transaction do
+      run.lock!
+      return nil if run.status != status
+
+      run.update_attribute(:status, Run::JUDGING)
+
+      run
+    end
+  end
 end

--- a/spec/services/grader_spec.rb
+++ b/spec/services/grader_spec.rb
@@ -1,0 +1,46 @@
+require 'grader'
+
+describe Grader do
+  self.use_transactional_fixtures = false
+
+  let(:grade_run) { double(GradeRun) }
+  let(:sync_tests) { double(SyncTests) }
+
+  before(:each) do
+    DatabaseCleaner.strategy = :truncation
+
+    allow(SyncTests).to receive(:new).and_return(sync_tests)
+    allow(sync_tests).to receive(:call).and_return(Time.now)
+  end
+
+  after(:each) do
+    DatabaseCleaner.clean
+  end
+
+  it "calls the grader run service object with the pending run to be tested" do
+    run1 = create(:run, status: Run::WAITING)
+
+    expect(GradeRun).to receive(:new).with(run1).and_return(grade_run)
+    expect(grade_run).to receive(:call).and_return(true)
+
+    Grader.new.find_and_grade_run
+  end
+
+  it "grades two runs simultaniously" do
+    run1 = create(:run, status: Run::WAITING)
+    run2 = create(:run, status: Run::WAITING)
+
+    pid1 = fork { Grader.new.find_and_grade_run }
+    pid2 = fork { Grader.new.find_and_grade_run }
+
+    Process.waitall
+
+    # Make sure the second run will be judged if the 2 runs above fight for the first run
+    pid3 = fork { Grader.new.find_and_grade_run }
+
+    Process.waitall
+
+    expect(run1.reload.status).to eq('')
+    expect(run2.reload.status).to eq('')
+  end
+end


### PR DESCRIPTION
This change makes sure that concurrent graders work with different runs. This is done by DB level locking primitives.

The code holds the locks for as little as possible, so that the workers are not blocked waiting.