### PR TITLE
Strip invalid UTF-8 characters from the log files before scanning them

### DIFF
--- a/app/models/run.rb
+++ b/app/models/run.rb
@@ -85,11 +85,15 @@ class Run < ActiveRecord::Base
 
   def update_time_and_mem
     if self.log
-      max_time = self.log.scan(/Used time: ([0-9\.]+)/).map { |t| BigDecimal.new(t.first) }.max
-      max_memory = self.log.scan(/Used mem: ([0-9]+)/).map(&:first).map(&:to_i).max
+      max_time = replace_invalid_utf8_chars(self.log).scan(/Used time: ([0-9\.]+)/).map { |t| BigDecimal.new(t.first) }.max
+      max_memory = replace_invalid_utf8_chars(self.log).scan(/Used mem: ([0-9]+)/).map(&:first).map(&:to_i).max
 
       self.max_time = max_time
       self.max_memory = max_memory
     end
+  end
+
+  def replace_invalid_utf8_chars(str)
+    str.encode('UTF-8', 'binary', invalid: :replace, undef: :replace, replace: '')
   end
 end

--- a/spec/models/run_spec.rb
+++ b/spec/models/run_spec.rb
@@ -1,0 +1,22 @@
+describe Run do
+  describe "#update_time_and_mem" do
+    let(:run) { create(:run) }
+
+    it "saves the max time and memory from the log" do
+      run.log = "Used time: 1\nUsed time: 2\nUsed mem: 6\nUsed mem: 5"
+
+      run.update_time_and_mem
+
+      expect(run.max_time).to eq(2)
+      expect(run.max_memory).to eq(6)
+    end
+
+    it "handles invalid UTF-8 characters" do
+      run.log = "Used time: 1234\255"
+
+      run.update_time_and_mem
+
+      expect(run.max_time).to eq(1234)
+    end
+  end
+end


### PR DESCRIPTION
Added specs for this exception and fixed the time and memory scanner to strip the invalid UTF-8 sequences.