### PR TITLE
Replace cpuset with cpuset-cpus because of deprecation.

### DIFF
--- a/app/services/grade_run.rb
+++ b/app/services/grade_run.rb
@@ -68,7 +68,7 @@ class GradeRun
       run.problem.input_files[0...tests].zip(run.problem.output_files).map { |input_file, answer_file|
         command = %Q{docker run #{ mappings(input_file) }\
           -m #{docker_memory_limit}\
-          --cpuset=0\
+          --cpuset-cpus=0\
           -u grader -d --net=none grader\
            /sandbox/runner_fork.rb -i /sandbox/input -o /sandbox/output -p 50 -m #{memory_limit} -t #{ timeout } -- #{ executable }}
         puts command


### PR DESCRIPTION
This merge requests updates the grader's docker running command to use `--cpuset-cpus` instead of `--cpuset`.

As of Docker 1.7.0 `--cpuset` is being replaced by `--cpuset-cpus`. Soon `--cpuset` will be completely deprecated as the docker on the production server warns (arena.maycamp.com):

![Warning on the production server](https://cloud.githubusercontent.com/assets/6758566/14049820/02e61b50-f2b8-11e5-97cf-f998fa591579.png)


The changes have been tested on `Docker 1.9.1` 

![Development environment](https://cloud.githubusercontent.com/assets/6758566/14049825/0a1c7806-f2b8-11e5-9426-825cb0cc67a3.png)

but according to the official docker [changelog](https://github.com/docker/docker/blob/master/CHANGELOG.md), the update should work for every docker version after 1.7.0 - see [here](https://lime-technology.com/forum/index.php?topic=36257.0).

### References:
* [Official Docker documentation](https://docs.docker.com/engine/reference/run/#cpuset-constraint)
* [Lime technology forum](https://lime-technology.com/forum/index.php?topic=36257.0)