### PR TITLE
Make the current and upcoming contests visible by default

### DIFF
--- a/app/views/main/_current_contests.html.erb
+++ b/app/views/main/_current_contests.html.erb
@@ -7,7 +7,7 @@
 			</a>
 		</h4>
 	</div>
-	<div id="collapseCurrentContests" class="panel-collapse collapse" role="tabpanel" aria-labelledby="headingCurrentContests">
+	<div id="collapseCurrentContests" class="panel-collapse collapse in" role="tabpanel" aria-labelledby="headingCurrentContests">
 		<div class="panel-body">
 
 			<table class="table table-bordered table-hover">

--- a/app/views/main/_upcoming_contests.html.erb
+++ b/app/views/main/_upcoming_contests.html.erb
@@ -7,7 +7,7 @@
       </a>
     </h4>
   </div>
-  <div id="collapseUpcomingContests" class="panel-collapse collapse" role="tabpanel" aria-labelledby="headingUpcomingContests">
+  <div id="collapseUpcomingContests" class="panel-collapse collapse in" role="tabpanel" aria-labelledby="headingUpcomingContests">
     <div class="panel-body">
       <table class="table table-bordered table-hover">
         <tr>


### PR DESCRIPTION
If there are current or upcoming contests the sections should be visible
by default.